### PR TITLE
Fix `.travis-output.py` path and fix bash warning

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -20,9 +20,9 @@ $SPACER
 start_section "conda.build" "${GREEN}Building..${NC}"
 if [ $TRAVIS_OS_NAME != 'windows' ]; then
     if [ $KEEP_ALIVE = 'true' ]; then
-        travis_wait $TRAVIS_MAX_TIME $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
+        travis_wait $TRAVIS_MAX_TIME $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
     else
-        $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
+        $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
     fi
 else
     # Work-around: prevent console output being mangled

--- a/script.sh
+++ b/script.sh
@@ -18,8 +18,8 @@ end_section "conda.check"
 $SPACER
 
 start_section "conda.build" "${GREEN}Building..${NC}"
-if [ $TRAVIS_OS_NAME != 'windows' ]; then
-    if [ $KEEP_ALIVE = 'true' ]; then
+if [[ $TRAVIS_OS_NAME != 'windows' ]]; then
+    if [[ $KEEP_ALIVE = 'true' ]]; then
         travis_wait $TRAVIS_MAX_TIME $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS
     else
         $CONDA_PATH/bin/python $TRAVIS_BUILD_DIR/.travis/.travis-output.py /tmp/output.log conda build $CONDA_BUILD_ARGS


### PR DESCRIPTION
This PR:
* Fix `.travis-output.py` path - this file was moved to `.travis` in one of previous PR, but path remaind unchanged
* Fix bash warning on string comparison without `" "`