### PR TITLE
Fix never-ending `conda render` bug by forcing `conda-build` v3.20.3

### DIFF
--- a/conda-get.sh
+++ b/conda-get.sh
@@ -38,14 +38,18 @@ conda config --prepend pkgs_dirs ~/.conda/pkg
 conda config --show
 
 echo "python==3.7.*" > $CONDA_PATH/conda-meta/pinned
-#echo "conda-build==3.14.0" >> $CONDA_PATH/conda-meta/pinned
-
 conda install -y python
+
+# `conda` has to be updated before pinning `conda-build`.
+# Otherwise it automatically installs `conda-build` which
+# is then removed by the `conda update -y --all` -- BUG??
 conda update -y conda
 
-conda install -y conda-build
-conda install -y conda-verify
+# Version has to be both pinned and passed to `conda install`
+echo "conda-build==3.20.3" >> $CONDA_PATH/conda-meta/pinned
+conda install -y conda-build==3.20.3
 
+conda install -y conda-verify
 if [ $TRAVIS_OS_NAME != 'windows' ]; then
     conda install -y ripgrep
 fi


### PR DESCRIPTION
`conda-build` v3.20.4 introduces a bug which causes never-ending rendering after issuing `conda render`.
The only output is:
```
write() argument must be str, not bytes
```
which is printed multiple times.

Based on `litex-conda-eda` testing it affects most of the recipes (e.g. `vtr`), but not all. `verilator` and `prjtrellis` are the ones from the "No dependencies" stage that doesn't seem to be affected.

This change proved to fix building from (that's pure `master`):
https://travis-ci.com/github/antmicro/litex-conda-eda/builds/193423609
to:
https://travis-ci.com/github/antmicro/litex-conda-eda/builds/193696091