### PR TITLE
Restore master-package.sh conditional execution

### DIFF
--- a/after_success.sh
+++ b/after_success.sh
@@ -32,7 +32,7 @@ else
         check_path="$ANACONDA_USER/$name/$version/$os_and_package"
         branch="$(git rev-parse --abbrev-ref HEAD)"
 
-        if anaconda show $check_path |& egrep "^labels.*'main'"; then
+        if anaconda show $check_path 2>&1 | grep -E "^labels.*'main'"; then
             echo "Package $check_path is present in main label. Uploading will be skipped because doing so would remove the 'main' one."
             exit 1
         else

--- a/after_success.sh
+++ b/after_success.sh
@@ -24,7 +24,7 @@ else
         [[ $CONDA_OUT =~ $os_package_match ]]
         os_and_package="${BASH_REMATCH[1]}"
 
-        name_version_match='conda-bld/(.*)/(.*)-(.*)-'
+        name_version_match='conda-bld/(.*)/(.*)-([^-]*)-[^-]*$'
         [[ $CONDA_OUT =~ $name_version_match ]]
         name="${BASH_REMATCH[2]}"
         version="${BASH_REMATCH[3]}"

--- a/after_success.sh
+++ b/after_success.sh
@@ -30,7 +30,13 @@ else
         version="${BASH_REMATCH[3]}"
 
         check_path="$ANACONDA_USER/$name/$version/$os_and_package"
+        # This command may return non-zero exit code when
+        # the package doesn't exist in this version in Anaconda
+        # and it's okay
+        set +e
         labels=$(anaconda show $check_path |& egrep "^labels.*'main'")
+        set -e
+
         force_param="--force"
         if [[ "$labels" == *"main"* ]]; then
             echo "Package $check_path is present in main label. Disabling --force parameter in anaconda upload..."

--- a/after_success.sh
+++ b/after_success.sh
@@ -19,8 +19,28 @@ else
         start_section "package.upload" "${GREEN}Package uploading...${NC}"
         # Test `anaconda` with ANACONDA_TOKEN before uploading
         source $GITHUB_WORKSPACE/.github/scripts/test_anaconda.sh
+
+        os_package_match='conda-bld/(.*)'
+        [[ $CONDA_OUT =~ $os_package_match ]]
+        os_and_package="${BASH_REMATCH[1]}"
+
+        name_version_match='conda-bld/(.*)/(.*)-(.*)-'
+        [[ $CONDA_OUT =~ $name_version_match ]]
+        name="${BASH_REMATCH[2]}"
+        version="${BASH_REMATCH[3]}"
+
+        check_path="$ANACONDA_USER/$name/$version/$os_and_package"
+        labels=$(anaconda show $check_path |& egrep "^labels.*'main'")
+        force_param="--force"
+        if [[ "$labels" == *"main"* ]]; then
+            echo "Package $check_path is present in main label. Disabling --force parameter in anaconda upload..."
+            force_param=""
+        else
+            echo "Package $check_path not present in 'main' label"
+        fi
+
         branch="$(git rev-parse --abbrev-ref HEAD)"
-        anaconda -t $ANACONDA_TOKEN upload --force --no-progress --user $ANACONDA_USER --label ci-$branch-$GITHUB_RUN_ID $CONDA_OUT
+        anaconda -t $ANACONDA_TOKEN upload $force_param --no-progress --user $ANACONDA_USER --label ci-$branch-$GITHUB_RUN_ID $CONDA_OUT
         end_section "package.upload"
     else
         echo "ANACONDA_TOKEN not found. Please consult README of litex-conda-ci for details on setting up tests properly."

--- a/common.sh
+++ b/common.sh
@@ -88,7 +88,7 @@ function start_section() {
 
 function end_section() {
 	echo -e "${GRAY}-------------------------------------------------------------------${NC}"
-	echo ::endgroup::
+	echo "::endgroup::"
 }
 
 export PYTHONWARNINGS=ignore::UserWarning:conda_build.environ

--- a/master-package.sh
+++ b/master-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 source $GITHUB_WORKSPACE/.github/scripts/common.sh
 # `for ... in $(anaconda ...` fails silently if there's any problem with anaconda
 source $GITHUB_WORKSPACE/.github/scripts/test_anaconda.sh

--- a/wait-for-statuses.py
+++ b/wait-for-statuses.py
@@ -46,10 +46,10 @@ with urllib.request.urlopen(status_url) as url:
       jobFailure = True
       break
 
-branch = subprocess.check_output("git rev-parse --abbrev-ref HEAD", text=True, shell=True)
+branch = os.environ.get('GITHUB_REF', '')
 # Upload packages only when whole build succeeded
 # and we are on master branch
-if(branch == 'master\n'):
+if(branch == 'refs/heads/master'):
   if(not jobFailure):
     subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],
                                  ".github/scripts/master-package.sh"))

--- a/wait-for-statuses.py
+++ b/wait-for-statuses.py
@@ -7,7 +7,7 @@ import sys
 
 # We're limited to this number by GH Actions API
 # https://docs.github.com/en/free-pro-team@latest/rest/reference/actions#list-jobs-for-a-workflow-run
-max_jobs=100
+max_jobs = 100
 
 status_url = "https://api.github.com/repos/" \
          + os.environ['GITHUB_REPOSITORY'] \

--- a/wait-for-statuses.py
+++ b/wait-for-statuses.py
@@ -46,10 +46,15 @@ with urllib.request.urlopen(status_url) as url:
       jobFailure = True
       break
 
+branch = subprocess.check_output("git rev-parse --abbrev-ref HEAD", text=True, shell=True)
 # Upload packages only when whole build succeeded
-if(not jobFailure):
-  subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],
-                               ".github/scripts/master-package.sh"))
+# and we are on master branch
+if(branch == 'master\n'):
+  if(not jobFailure):
+    subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],
+                                 ".github/scripts/master-package.sh"))
+else:
+  print("Not on master branch, don't execute master-package.sh. Current branch: " + str(branch))
 
 # Always clean up
 subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],


### PR DESCRIPTION
master-package.sh needs to be executed only for 'master' branch. It is responsible for moving packages from temporary anaconda label to main label. This PR fixes that. It also raises verbosity of master-package.sh script by setting -x flag in shell.