### PR TITLE
Fix script paths

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,18 +12,21 @@ runs:
           export PATH="$PATH:/c/ProgramData/Chocolatey/bin/"
           export PATH="$PATH:/c/Program Files/Git/usr/bin/"
         fi
-        source .github/scripts/common.sh
-        bash .github/scripts/download_sdk.sh
-        bash .github/scripts/install.sh
+        # Used in the scripts to locate other scripts.
+        export CI_SCRIPTS_PATH="$GITHUB_ACTION_PATH"
+
+        source $GITHUB_ACTION_PATH/common.sh
+        bash $GITHUB_ACTION_PATH/download_sdk.sh
+        bash $GITHUB_ACTION_PATH/install.sh
         set -x
         if [ $SCRIPT ]; then
           bash $SCRIPT
         else
-          bash .github/scripts/script.sh
+          bash $GITHUB_ACTION_PATH/script.sh
         fi
         if [ $? -eq 0 ]; then
-          source .github/scripts/after_success.sh
+          source $GITHUB_ACTION_PATH/after_success.sh
         else
-          source .github/scripts/after_failure.sh
+          source $GITHUB_ACTION_PATH/after_failure.sh
         fi
       shell: bash

--- a/after_failure.sh
+++ b/after_failure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 
 # Close the after_failure fold
 echo ::endgroup::

--- a/after_success.sh
+++ b/after_success.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 set -e
 
 # Close the after_success fold
@@ -18,7 +18,7 @@ else
 
         start_section "package.upload" "${GREEN}Package uploading...${NC}"
         # Test `anaconda` with ANACONDA_TOKEN before uploading
-        source $GITHUB_WORKSPACE/.github/scripts/test_anaconda.sh
+        source $CI_SCRIPTS_PATH/test_anaconda.sh
 
         os_package_match='conda-bld/(.*)'
         [[ $CONDA_OUT =~ $os_package_match ]]

--- a/cleanup-anaconda.sh
+++ b/cleanup-anaconda.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 # `for ... in $(anaconda ...` fails silently if there's any problem with anaconda
-source $GITHUB_WORKSPACE/.github/scripts/test_anaconda.sh
+source $CI_SCRIPTS_PATH/test_anaconda.sh
 
 set -e
 set -x

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 set -e
 
 # Getting the conda environment
 start_section "environment.conda" "Setting up basic ${YELLOW}conda environment${NC}"
 
 mkdir -p $BASE_PATH
-$GITHUB_WORKSPACE/.github/scripts/conda-get.sh $CONDA_PATH
+$CI_SCRIPTS_PATH/conda-get.sh $CONDA_PATH
 hash -r
 
 if [ x$PACKAGE = x"" ]; then
@@ -16,7 +16,7 @@ if [ x$PACKAGE = x"" ]; then
 fi
 
 # Add build variants to the recipe dir (appended keys win in case of any conflict)
-cat "$GITHUB_WORKSPACE/.github/scripts/conda_build_config.yaml" >> "$PACKAGE/conda_build_config.yaml"
+cat "$CI_SCRIPTS_PATH/conda_build_config.yaml" >> "$PACKAGE/conda_build_config.yaml"
 
 # Install conda-build-prepare
 python -m pip install git+https://github.com/litex-hub/conda-build-prepare@v0.1.1#egg=conda-build-prepare
@@ -39,7 +39,7 @@ fi
 python -m conda_build_prepare --channels $ADDITIONAL_CHANNELS --packages $ADDITIONAL_PACKAGES --dir workdir $PACKAGE
 
 # Freshly created conda environment will be activated by the common.sh
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 
 end_section "environment.conda"
 

--- a/master-package.sh
+++ b/master-package.sh
@@ -2,9 +2,9 @@
 
 set -x
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 # `for ... in $(anaconda ...` fails silently if there's any problem with anaconda
-source $GITHUB_WORKSPACE/.github/scripts/test_anaconda.sh
+source $CI_SCRIPTS_PATH/test_anaconda.sh
 
 branch="$(git rev-parse --abbrev-ref HEAD)"
 # Move all packages from the current label to the main label

--- a/script.sh
+++ b/script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $GITHUB_WORKSPACE/.github/scripts/common.sh
+source $CI_SCRIPTS_PATH/common.sh
 set -e
 
 $SPACER

--- a/wait-for-statuses.py
+++ b/wait-for-statuses.py
@@ -46,19 +46,19 @@ with urllib.request.urlopen(status_url) as url:
       jobFailure = True
       break
 
+scripts_dir = os.environ['CI_SCRIPTS_PATH']
+
 branch = os.environ.get('GITHUB_REF', '')
 # Upload packages only when whole build succeeded
 # and we are on master branch
 if(branch == 'refs/heads/master'):
   if(not jobFailure):
-    subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],
-                                 ".github/scripts/master-package.sh"))
+    subprocess.call(os.path.join(scripts_dir, "master-package.sh"))
 else:
   print("Not on master branch, don't execute master-package.sh. Current branch: " + str(branch))
 
 # Always clean up
-subprocess.call(os.path.join(os.environ['GITHUB_WORKSPACE'],
-                             ".github/scripts/cleanup-anaconda.sh"))
+subprocess.call(os.path.join(scripts_dir, "cleanup-anaconda.sh"))
 
 if(jobFailure):
   sys.exit("ERROR: some jobs failed")


### PR DESCRIPTION
Previously the action was calling scripts from the revision used as a
submodule in the repositories using this repository. After this change
the scripts from the same commit as the action run will always be used.

Then we'll be able to remove `.github/scripts` submodules from `conda-*` repositories.